### PR TITLE
Close all connections

### DIFF
--- a/R/importAURN.R
+++ b/R/importAURN.R
@@ -331,7 +331,7 @@ importAURN <- function(site = "my1", year = 2009, pollutant = "all", hc = FALSE)
              fileName <- paste("http://uk-air.defra.gov.uk/openair/R_data/", x, ".RData", sep = "")
              con <- url(fileName)
              load(con, envir = .GlobalEnv)
-             close(con)
+             closeAllConnections() # CV: use closeAllConnections() rather than close(con)!
              
              x
              },


### PR DESCRIPTION
When you retrieve numerous data sets, the function crashes as it reaches the maximum number of connections open. You could avoid this limitation by using closeAllConnections() rather than close(con) in line 334.